### PR TITLE
Using instance Zend_Form_Element instead of directly adding an element to the form.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ class Application_Form_Example extends Twitter_Bootstrap3_Form_*
     }
 }
 ```
-## OR
+#### OR
 
 ```php
 class Application_Form_Example extends Twitter_Bootstrap3_Form_*

--- a/README.md
+++ b/README.md
@@ -5,6 +5,34 @@
 The library supports all Bootstrap 3 form types.
 
 ### One PHP code
+```php
+class Application_Form_Example extends Twitter_Bootstrap3_Form_*
+{
+    public function init()
+    {
+        $email = new Twitter_Bootstrap3_Form_Element_Email('email');
+        $email->setLabel('Email')->setAttrib('placeholder', 'Email');
+
+        $password = new Zend_Form_Element_Password('password');
+        $password->setLabel('Password')->setAttrib('placeholder', 'Password');
+
+        $checkbox = new Zend_Form_Element_Checkbox('checkbox');
+        $checkbox->setLabel('Remember me');
+
+        $submit = new Zend_Form_Element_Submit('submit');
+        $submit->setLabel('Sign in');
+
+        $this->addElements(array(
+            $email,
+            $password,
+            $checkbox,
+            $submit1
+
+        ));
+    }
+}
+```
+## OR
 
 ```php
 class Application_Form_Example extends Twitter_Bootstrap3_Form_*

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ class Application_Form_Example extends Twitter_Bootstrap3_Form_*
             $email,
             $password,
             $checkbox,
-            $submit1
+            $submit
 
         ));
     }

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "zfbase/zend1-bootstrap3",
+    "name": "wendrowycz/zend1-bootstrap3",
     "description": "Twitter Bootstrap v.3 Forms for Zend Framework v.1",
     "require": {
         "php": ">=5.3.0",

--- a/library/Twitter/Bootstrap3/Form.php
+++ b/library/Twitter/Bootstrap3/Form.php
@@ -366,6 +366,72 @@ abstract class Twitter_Bootstrap3_Form extends Zend_Form
         
         return parent::createElement($type, $name, $options);
     }
+
+    /**
+     * Add a new element
+     *
+     * $element may be either a string element type, or an object of type
+     * Zend_Form_Element. If a string element type is provided, $name must be
+     * provided, and $options may be optionally provided for configuring the
+     * element.
+     *
+     * If a Zend_Form_Element is provided, $name may be optionally provided,
+     * and any provided $options will be ignored.
+     *
+     * @param  string|Zend_Form_Element $element
+     * @param  string $name
+     * @param  array|Zend_Config $options
+     * @throws Zend_Form_Exception on invalid element
+     * @return Zend_Form
+     */
+    public function addElement($element, $name = null, $options = null)
+    {
+        if ($element instanceof Zend_Form_Element) {
+            $type = lcfirst(str_replace('Twitter_Bootstrap3_Form_Element_', '', $element->getType()));
+
+            if (null !== $options && $options instanceof Zend_Config) {
+                $options = $options->toArray();
+            }
+
+            // Load default decorators
+            if ((null === $options) || !is_array($options)) {
+                $options = array();
+            }
+
+            if (!array_key_exists('decorators', $options)) {
+                $decorators = $this->getDefaultDecoratorsByElementType($type);
+                if (!empty($decorators)) {
+                    $options['decorators'] = $decorators;
+                }
+            }
+
+            // Elements type use 'form-control' class
+            $element_fc = array(
+                // all input:
+                'text', 'password', 'dateTime', 'dateTimeLocal', 'date', 'month',
+                'time', 'week', 'number', 'email', 'url', 'search', 'tel', 'color',
+                // and other:
+                'textarea', 'select', 'multiselect',
+            );
+            if (in_array($type, $element_fc)) {
+                if (null === $options) {
+                    $options = array('class' => 'form-control');
+                } elseif (array_key_exists('class', $options)) {
+                    if (!strstr($options['class'], 'form-control')) {
+                        $options['class'] .= ' form-control';
+                        $options['class'] = trim($options['class']);
+                    }
+                } else {
+                    $options['class'] = 'form-control';
+                }
+            }
+
+            $element->setOptions($options);
+
+        }
+
+        parent::addElement($element, $name, $options);
+    }
     
     /**
      * Retrieve a registered decorator for type element

--- a/library/Twitter/Bootstrap3/Form.php
+++ b/library/Twitter/Bootstrap3/Form.php
@@ -387,7 +387,8 @@ abstract class Twitter_Bootstrap3_Form extends Zend_Form
     public function addElement($element, $name = null, $options = null)
     {
         if ($element instanceof Zend_Form_Element) {
-            $type = lcfirst(str_replace('Twitter_Bootstrap3_Form_Element_', '', $element->getType()));
+            // type string
+            $type = lcfirst(trim(end(explode('_', $element->getType()))));
 
             if (null !== $options && $options instanceof Zend_Config) {
                 $options = $options->toArray();


### PR DESCRIPTION
In our projects, we use object instances Zend_Form_Elements instead of directly adding them to the form. Thanks to keep the transparency of the code and it is easier to manage. Since decorators in this case were not supported, I overwrite standard method addElement to handle this in a way as direct adding form elements.